### PR TITLE
fix typo in url validation function

### DIFF
--- a/lib/validation/format.ts
+++ b/lib/validation/format.ts
@@ -232,7 +232,7 @@ const formatValidators: Record<
         if (value === "" || validUrl.isWebUri(value)) {
             return undefined;
         }
-        return errors.formatUrlError({ value, pointer });
+        return errors.formatURLError({ value, pointer });
     }
 };
 


### PR DESCRIPTION
typo: "formatUrlError" instead of "formatURLError", which is defined in `errors.ts`. fixes `formatUrlError is not a function` exception when validating an url