### PR TITLE
fix: oneOf step loses compiled reference resolution

### DIFF
--- a/lib/step.ts
+++ b/lib/step.ts
@@ -144,7 +144,6 @@ const stepType = {
 
                 const oneOfIndex = targetSchema.oneOf.findIndex((s) => s === resolvedSchema);
 
-                resolvedSchema = JSON.parse(JSON.stringify(resolvedSchema));
                 resolvedSchema.variableSchema = true;
                 resolvedSchema.oneOfIndex = oneOfIndex;
                 resolvedSchema.oneOfSchema = targetSchema;


### PR DESCRIPTION
Due to much of the ref resolution stored within a schema as non-enumerable properties, there needs to be serious care when running a copy/clone operation on the schema. I'm wary of the mutation that will now occur, however I'm not sure what the consequence of that will be.