### PR TITLE
feat: oneOf pointer w/o data should return schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ expect(calls).to.deep.equal([
 
 ### getSchema
 
-`getSchema` retrieves the json-schema of a specific location in data. The location in data is given by a _json-pointer_. In many cases the schema can be retrieved without passing the actual data, but in situations where the schema is dynamic (e.g., in _oneOf_, _dependencies_, etc.), the data is required or will return a _JsonError_ if the location cannot be found.
+`getSchema` retrieves the json-schema of a specific location in data. The location in data is given by a _json-pointer_. In many cases the schema can be retrieved without passing the actual data.
 
 ```ts
 const jsonSchema = new Draft07(mySchema);

--- a/lib/step.ts
+++ b/lib/step.ts
@@ -102,7 +102,7 @@ const stepType: Record<string, StepFunction> = {
             // check if there is a oneOf selection, which must be resolved
             if (targetSchema && Array.isArray(targetSchema.oneOf)) {
                 // if no data is supplied, return the full targetSchema
-                if(!data || !data[key]) {
+                if(data === undefined || data[key] === undefined) {
                     return targetSchema
                 }
                 // @special case: this is a mix of a schema and optional definitions

--- a/lib/step.ts
+++ b/lib/step.ts
@@ -101,6 +101,10 @@ const stepType: Record<string, StepFunction> = {
 
             // check if there is a oneOf selection, which must be resolved
             if (targetSchema && Array.isArray(targetSchema.oneOf)) {
+                // if no data is supplied, return the full targetSchema
+                if(!data || !data[key]) {
+                    return targetSchema
+                }
                 // @special case: this is a mix of a schema and optional definitions
                 // we resolve the schema here and add the original schema to `oneOfSchema`
                 return draft.resolveOneOf(data[key], targetSchema, `${pointer}/${key}`);


### PR DESCRIPTION
this is the breaking change version

**if a non-breaking change is preferred, I can propose an alternative PR** where we add a `getRawSchema()` that passes a config option to `step()` to behave this way

this is a fantastic library for the codemirror 6 mode we are building, however we've had to
[patch](https://github.com/acao/cm6-language-json-schema/pull/2/files#diff-84b470e1f66294b6222e35877b2d17f64a790ffb6d5e862584030cc2341f31ea) for this, which we can't ship with obviously.

what do you think?