### PR TITLE
alternative, non-breaking: `skipDataResolution` and `getRawSchema`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ What follows is a description of the main draft methods.
 -   [each](#each)
 -   [eachSchema](#eachschema)
 -   [getSchema](#getschema)
+-   [getRawSchema](#getrawschema)
 -   [getChildSchemaSelection](#getchildschemaselection)
 -   [step](#step)
 -   [addRemoteSchema](#addremoteschema)
@@ -418,6 +419,94 @@ expect(schemaOfItem).to.deep.equal({
             title: "name of item"
         }
     }
+});
+```
+
+</details>
+
+<details><summary>About JsonPointer</summary>
+
+**[Json-Pointer](https://tools.ietf.org/html/rfc6901)** defines a string syntax for identifying a specific value within a Json document and is [supported by Json-Schema](https://json-schema.org/understanding-json-schema/structuring.html). Given a Json document, it behaves similar to a [lodash path](https://lodash.com/docs/4.17.5#get) (`a[0].b.c`), which follows JS-syntax, but instead uses `/` separators (e.g., `a/0/b/c`). In the end, you describe a path into the Json data to a specific point.
+
+</details>
+
+### getRawSchema
+
+`getRawSchema` retrieves the json-schema of a specific location without data. The location in data is given by a _json-pointer_. In situations where the schema is dynamic, it returns the entire schema for that pointer
+
+```ts
+const jsonSchema = new Draft07(mySchema);
+let schemaOfName: JsonSchema | JsonError;
+schemaOfName = jsonSchema.getRawSchema("/list/1/name");
+```
+
+<details><summary>Example</summary>
+
+```ts
+import { Draft07, JsonSchema, JsonError } from "json-schema-library";
+
+const mySchema = {
+    type: "object",
+    properties: {
+        list: {
+            type: "array",
+            items: {
+                description: "Example oneOf type",
+                oneOf: [
+                    {
+                        type: "object",
+                        required: ["name"],
+                        properties: {
+                            name: {
+                                type: "string",
+                                title: "name of item"
+                            }
+                        }
+                    },
+                    {
+                        type: "object",
+                        required: ["description"],
+                        properties: {
+                            description: {
+                                type: "string",
+                                title: "description of item"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+};
+
+const jsonSchema = new Draft07(mySchema);
+let schemaOfItem: JsonSchema | JsonError;
+schemaOfItem = jsonSchema.getRawSchema("/list/1");
+
+expect(schemaOfItem).to.deep.equal({
+    description: "Example oneOf type",
+    oneOf: [
+        {
+            type: "object",
+            required: ["name"],
+            properties: {
+                name: {
+                    type: "string",
+                    title: "name of item"
+                }
+            }
+        },
+        {
+            type: "object",
+            required: ["description"],
+            properties: {
+                description: {
+                    type: "string",
+                    title: "description of item"
+                }
+            }
+        }
+    ]
 });
 ```
 

--- a/lib/draft/index.ts
+++ b/lib/draft/index.ts
@@ -189,8 +189,8 @@ export class Draft {
      * @param  [pointer] - pointer to schema and data (parent of key)
      * @return Schema or Error if failed resolving key
      */
-    step(key: string | number, schema: JsonSchema, data: any, pointer?: JsonPointer): JsonSchema {
-        return this.config.step(this, key, schema, data, pointer);
+    step(key: string | number, schema: JsonSchema, data: any, pointer?: JsonPointer, skipDataResolution?: boolean): JsonSchema {
+        return this.config.step(this, key, schema, data, pointer, skipDataResolution);
     }
 
     /**

--- a/lib/getRawSchema.ts
+++ b/lib/getRawSchema.ts
@@ -2,30 +2,25 @@ import gp from "@sagold/json-pointer";
 import { JsonSchema, JsonPointer, isJsonError } from "./types";
 import { Draft } from "./draft";
 
-const emptyObject = {};
-
 /**
- * Returns the json-schema of a data-json-pointer.
+ * Returns the json-schema of a data-json-pointer without resolving data
  *
  *  Notes
  *      - Uses draft.step to walk through data and schema
  *
  * @param draft
  * @param pointer - json pointer in data to get the json schema for
- * @param [data] - the data object, which includes the json pointers value. This is optional, as
- *    long as no oneOf, anyOf, etc statement is part of the pointers schema
  * @param [schema] - the json schema to iterate. Defaults to draft.rootSchema
  * @return json schema object of the json-pointer or an error
  */
-export default function getSchema(
+export default function getRawSchema(
     draft: Draft,
     pointer: JsonPointer,
-    data?: unknown,
-    schema: JsonSchema = draft.rootSchema
+    schema: JsonSchema = draft.rootSchema,
 ): JsonSchema {
     const frags = gp.split(pointer);
     schema = draft.resolveRef(schema);
-    return _get(draft, schema, frags, pointer, data);
+    return _get(draft, schema, frags, pointer);
 }
 
 function _get(
@@ -33,18 +28,15 @@ function _get(
     schema: JsonSchema,
     frags: Array<string>,
     pointer: JsonPointer,
-    data: unknown = emptyObject
 ): JsonSchema {
     if (frags.length === 0) {
         return draft.resolveRef(schema);
     }
 
     const key = frags.shift(); // step key
-    schema = draft.step(key, schema, data, pointer); // step schema
+    schema = draft.step(key, schema, {}, pointer, true); // step schema
     if (isJsonError(schema)) {
         return schema;
     }
-    // @ts-expect-error data
-    data = data[key]; // step data
-    return _get(draft, schema, frags, `${pointer}/${key}`, data);
+    return _get(draft, schema, frags, `${pointer}/${key}`);
 }

--- a/lib/step.ts
+++ b/lib/step.ts
@@ -103,7 +103,7 @@ const stepType: Record<string, StepFunction> = {
             // check if there is a oneOf selection, which must be resolved
             if (targetSchema && Array.isArray(targetSchema.oneOf)) {
                 // if no data is supplied, return the full targetSchema
-                if (skipDataResolution && (!data || !data[key])) {
+                if (skipDataResolution && (data === undefined || !data[key] === undefined)) {
                     return targetSchema;
                 }
                 // @special case: this is a mix of a schema and optional definitions


### PR DESCRIPTION
this would be the non-breaking alternative to #41, exposing a new method that bypasses data resolution - this would be very handy for autocompletion/hover/etc in IDE tools, where we often don't even have a value yet, but still need to retrieve the `targetSchema` for a pointer

here is a real world use case:

![hover-oneOf](https://github.com/sagold/json-schema-library/assets/1368727/4f650854-1c01-4d8a-92a2-5dcf9bd34e7b)

the package.json schema json for `exports` fields includes a `description` field and other metadata that isn't accessible with `getSchema`, even if a value is provided! here we patched the library to get the desired effect, but it would be bad OSS library practice to ship with a patched version of your library of course
