### PR TITLE
Add undefined promise to return type of validation result

### DIFF
--- a/src/Keyword.ts
+++ b/src/Keyword.ts
@@ -36,7 +36,7 @@ export type JsonSchemaValidatorParams = { pointer?: string; data: unknown; node:
 export interface JsonSchemaValidator {
     toJSON?: () => string;
     order?: number;
-    (options: JsonSchemaValidatorParams): undefined | ValidationResult | ValidationResult[];
+    (options: JsonSchemaValidatorParams): undefined | Promise<undefined> | ValidationResult | ValidationResult[];
 }
 
 export type Keyword = {


### PR DESCRIPTION
`Promise<undefined>` is not a valid return type for async keywords, making it difficult to write these without wrestling with TypeScript.

Fixes https://github.com/sagold/json-schema-library/issues/94