### PR TITLE
feat: add JSON Schema Test Suite compliance badges

### DIFF
--- a/.github/scripts/parse-test-results.js
+++ b/.github/scripts/parse-test-results.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Parses mocha JSON reporter output for each draft and writes
+ * BADGE_DRAFTxx and COLOR_DRAFTxx env vars to $GITHUB_ENV.
+ *
+ * Mocha JSON reporter shape:
+ * {
+ *   stats: { passes: N, failures: N, pending: N },
+ *   ...
+ * }
+ */
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const drafts = [
+  { key: "DRAFT04",   file: "test-result-spec4.json" },
+  { key: "DRAFT06",   file: "test-result-spec6.json" },
+  { key: "DRAFT07",   file: "test-result-spec7.json" },
+  { key: "DRAFT2019", file: "test-result-spec2019-09.json" },
+  { key: "DRAFT2020", file: "test-result-spec2020-12.json" },
+];
+
+const githubEnv = process.env.GITHUB_ENV;
+const lines = [];
+
+for (const { key, file } of drafts) {
+  const filePath = path.resolve(process.cwd(), file);
+
+  let message = "unknown";
+  let color = "lightgrey";
+
+  if (fs.existsSync(filePath)) {
+    try {
+      const raw = fs.readFileSync(filePath, "utf8");
+      const json = JSON.parse(raw);
+      const passes = json?.stats?.passes ?? 0;
+      const failures = json?.stats?.failures ?? 0;
+      const total = passes + failures;
+
+      if (total === 0) {
+        message = "no tests";
+        color = "lightgrey";
+      } else if (failures === 0) {
+        message = `${passes}/${total} passing`;
+        color = "brightgreen";
+      } else {
+        const pct = Math.round((passes / total) * 100);
+        message = `${passes}/${total} passing`;
+        // Color scale: green >= 95%, yellow >= 80%, orange >= 60%, red < 60%
+        color = pct >= 95 ? "green" : pct >= 80 ? "yellow" : pct >= 60 ? "orange" : "red";
+      }
+    } catch (e) {
+      console.error(`Failed to parse ${file}:`, e.message);
+      message = "parse error";
+      color = "lightgrey";
+    }
+  } else {
+    console.warn(`Result file not found: ${file}`);
+    message = "not run";
+    color = "lightgrey";
+  }
+
+  console.log(`${key}: ${message} (${color})`);
+  lines.push(`BADGE_${key}=${message}`);
+  lines.push(`COLOR_${key}=${color}`);
+}
+
+if (githubEnv) {
+  fs.appendFileSync(githubEnv, lines.join(os.EOL) + os.EOL);
+  console.log("Written to GITHUB_ENV");
+} else {
+  // Local debug
+  console.log("\n--- Would write to GITHUB_ENV ---");
+  lines.forEach((l) => console.log(l));
+}

--- a/.github/workflows/badges.yaml
+++ b/.github/workflows/badges.yaml
@@ -1,0 +1,104 @@
+name: JSON Schema Test Suite Badges
+
+on:
+  push:
+    branches:
+      - main
+  workflow_run:
+    workflows: [CI]
+    types:
+      - completed
+
+jobs:
+  badges:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      # Run each draft's test suite and capture JSON output
+      - name: Run draft-04 tests
+        run: yarn test:4:ci
+        continue-on-error: true
+
+      - name: Run draft-06 tests
+        run: yarn test:6:ci
+        continue-on-error: true
+
+      - name: Run draft-07 tests
+        run: yarn test:7:ci
+        continue-on-error: true
+
+      - name: Run draft-2019-09 tests
+        run: yarn test:2019:ci
+        continue-on-error: true
+
+      - name: Run draft-2020-12 tests
+        run: yarn test:2020:ci
+        continue-on-error: true
+
+      # Parse results and set env variables for each draft
+      - name: Parse test results
+        id: parse
+        run: node .github/scripts/parse-test-results.js
+
+      # One badge per draft
+      - name: Badge - draft-04
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: ${{ secrets.BADGE_GIST_ID }}
+          filename: jsl-draft04.json
+          label: draft-04
+          message: ${{ env.BADGE_DRAFT04 }}
+          color: ${{ env.COLOR_DRAFT04 }}
+
+      - name: Badge - draft-06
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: ${{ secrets.BADGE_GIST_ID }}
+          filename: jsl-draft06.json
+          label: draft-06
+          message: ${{ env.BADGE_DRAFT06 }}
+          color: ${{ env.COLOR_DRAFT06 }}
+
+      - name: Badge - draft-07
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: ${{ secrets.BADGE_GIST_ID }}
+          filename: jsl-draft07.json
+          label: draft-07
+          message: ${{ env.BADGE_DRAFT07 }}
+          color: ${{ env.COLOR_DRAFT07 }}
+
+      - name: Badge - draft-2019-09
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: ${{ secrets.BADGE_GIST_ID }}
+          filename: jsl-draft2019-09.json
+          label: draft-2019-09
+          message: ${{ env.BADGE_DRAFT2019 }}
+          color: ${{ env.COLOR_DRAFT2019 }}
+
+      - name: Badge - draft-2020-12
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: ${{ secrets.BADGE_GIST_ID }}
+          filename: jsl-draft2020-12.json
+          label: draft-2020-12
+          message: ${{ env.BADGE_DRAFT2020 }}
+          color: ${{ env.COLOR_DRAFT2020 }}

--- a/.github/workflows/badges.yaml
+++ b/.github/workflows/badges.yaml
@@ -1,9 +1,6 @@
 name: JSON Schema Test Suite Badges
 
 on:
-  push:
-    branches:
-      - main
   workflow_run:
     workflows: [CI]
     types:
@@ -12,47 +9,54 @@ on:
 jobs:
   badges:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download spec-4 results
+        uses: actions/download-artifact@v4
+        with:
+          name: test-results-spec-4
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Download spec-6 results
+        uses: actions/download-artifact@v4
+        with:
+          name: test-results-spec-6
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Download spec-7 results
+        uses: actions/download-artifact@v4
+        with:
+          name: test-results-spec-7
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Download spec-2019-09 results
+        uses: actions/download-artifact@v4
+        with:
+          name: test-results-spec-2019-09
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Download spec-2020-12 results
+        uses: actions/download-artifact@v4
+        with:
+          name: test-results-spec-2020-12
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: yarn
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      # Run each draft's test suite and capture JSON output
-      - name: Run draft-04 tests
-        run: yarn test:4:ci
-        continue-on-error: true
-
-      - name: Run draft-06 tests
-        run: yarn test:6:ci
-        continue-on-error: true
-
-      - name: Run draft-07 tests
-        run: yarn test:7:ci
-        continue-on-error: true
-
-      - name: Run draft-2019-09 tests
-        run: yarn test:2019:ci
-        continue-on-error: true
-
-      - name: Run draft-2020-12 tests
-        run: yarn test:2020:ci
-        continue-on-error: true
-
-      # Parse results and set env variables for each draft
       - name: Parse test results
-        id: parse
         run: node .github/scripts/parse-test-results.js
 
-      # One badge per draft
       - name: Badge - draft-04
         uses: schneegans/dynamic-badges-action@v1.7.0
         with:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 [![Npm package version](https://badgen.net/npm/v/json-schema-library)](https://www.npmjs.com/package/json-schema-library) [![CI](https://github.com/sagold/json-schema-library/actions/workflows/ci.yaml/badge.svg)](https://github.com/sagold/json-schema-library/actions/workflows/ci.yaml) ![Types](https://badgen.net/npm/types/json-schema-library)
+![draft-04](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Adityakumar37/8e62d5f2312c1821398caf27f389f117/raw/jsl-draft04.json)
+![draft-06](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Adityakumar37/8e62d5f2312c1821398caf27f389f117/raw/jsl-draft06.json)
+![draft-07](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Adityakumar37/8e62d5f2312c1821398caf27f389f117/raw/jsl-draft07.json)
+![draft-2019-09](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Adityakumar37/8e62d5f2312c1821398caf27f389f117/raw/jsl-draft2019-09.json)
+![draft-2020-12](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Adityakumar37/8e62d5f2312c1821398caf27f389f117/raw/jsl-draft2020-12.json)
 
 <h1 align="center">
     <img src="./docs/json-schema-library-10.png" width="192" alt="json-schema-library">


### PR DESCRIPTION
Adds per-draft test suite badges to the README as discussed in #76 .



Each badge shows passing tests against the official JSON-Schema-Test-Suite for draft-04, draft-06, draft-07, draft-2019-09 and draft-2020-12.

**How it works:**
There are two new files — `.github/workflows/badges.yaml` which runs after CI and executes each draft's test suite, and `.github/scripts/parse-test-results.js` which parses the output and figures out the pass count and badge color. Results get pushed to a GitHub Gist via `schneegans/dynamic-badges-action` and shields.io reads from there.

I've left the Gist config as `GIST_SECRET` and `BADGE_GIST_ID` secrets so you can point it to your own Gist after merging — the README URLs would just need updating to match. Happy to do that once you have the Gist set up, or I can keep mine in temporarily if that's easier.

Would love to hear your thoughts on this!