### PR TITLE
Do not flag properties as unevaluated when they fail validation

### DIFF
--- a/src/keywords/unevaluatedProperties.test.ts
+++ b/src/keywords/unevaluatedProperties.test.ts
@@ -1,4 +1,5 @@
 import { compileSchema } from "../compileSchema";
+import { draft2020 } from "../draft2020";
 import { strict as assert } from "assert";
 
 describe("keyword : unevaluatedProperties : validation", () => {
@@ -12,5 +13,61 @@ describe("keyword : unevaluatedProperties : validation", () => {
             test: undefined
         });
         assert.equal(errors.length, 0);
+    });
+
+    it("should not return unevaluated-property-error for a property that fails format validation", () => {
+        const node = compileSchema(
+            {
+                type: "object",
+                properties: {
+                    name: { type: "string" },
+                    email: { type: "string", format: "email" }
+                },
+                unevaluatedProperties: false
+            },
+            { drafts: [draft2020] }
+        );
+
+        const { errors } = node.validate({ name: "Alice", email: "not-an-email" });
+
+        const unevaluatedErrors = errors.filter((e) => e.code === "unevaluated-property-error");
+        assert.equal(unevaluatedErrors.length, 0, "should not flag email as unevaluated");
+    });
+
+    it("should not return unevaluated-property-error for a property that fails type validation", () => {
+        const node = compileSchema(
+            {
+                type: "object",
+                properties: {
+                    name: { type: "string" },
+                    age: { type: "number" }
+                },
+                unevaluatedProperties: false
+            },
+            { drafts: [draft2020] }
+        );
+
+        const { errors } = node.validate({ name: "Alice", age: "not-a-number" });
+
+        const unevaluatedErrors = errors.filter((e) => e.code === "unevaluated-property-error");
+        assert.equal(unevaluatedErrors.length, 0, "should not flag age as unevaluated");
+    });
+
+    it("should still return unevaluated-property-error for truly unknown properties", () => {
+        const node = compileSchema(
+            {
+                type: "object",
+                properties: {
+                    name: { type: "string" }
+                },
+                unevaluatedProperties: false
+            },
+            { drafts: [draft2020] }
+        );
+
+        const { errors } = node.validate({ name: "Alice", unknown: "value" });
+
+        const unevaluatedErrors = errors.filter((e) => e.code === "unevaluated-property-error");
+        assert.equal(unevaluatedErrors.length, 1, "should flag unknown as unevaluated");
     });
 });

--- a/src/keywords/unevaluatedProperties.ts
+++ b/src/keywords/unevaluatedProperties.ts
@@ -56,6 +56,13 @@ function validateUnevaluatedProperties({ node, data, pointer, path }: JsonSchema
 
     const errors: ValidationReturnType = [];
     for (const propertyName of unevaluated) {
+        // properties defined directly on this schema object are always
+        // evaluated by the "properties" keyword, regardless of whether the
+        // value passes validation (per JSON Schema spec, annotations from
+        // adjacent keywords are always collected)
+        if (node.properties?.[propertyName]) {
+            continue;
+        }
         if (isPropertyEvaluated({ node, data, key: propertyName, pointer, path })) {
             continue;
         }

--- a/src/keywords/unevaluatedProperties.ts
+++ b/src/keywords/unevaluatedProperties.ts
@@ -56,7 +56,7 @@ function validateUnevaluatedProperties({ node, data, pointer, path }: JsonSchema
 
     const errors: ValidationReturnType = [];
     for (const propertyName of unevaluated) {
-        // properties defined directly on this schema object are always
+        // Properties defined directly on this schema object are always
         // evaluated by the "properties" keyword, regardless of whether the
         // value passes validation (per JSON Schema spec, annotations from
         // adjacent keywords are always collected)


### PR DESCRIPTION
Hi Sascha!

I encountered a strange behavior where fields that fail a format validation is marked as unevaluated. We have some logic to remove all unevaluated properties (so we don't end up submitting data that is not part of the schema), but this means we accidentally remove data that has simply failed validation.

To be more precise:

Properties defined directly in `properties` adjacent to `unevaluatedProperties` are always evaluated by the `properties` keyword, regardless of whether the value passes validation.

Previously, `validateUnevaluatedProperties` delegated entirely to `isPropertyEvaluated`, which required the property value to pass validation before marking it as evaluated. This caused false `unevaluated-property-error` reports for properties that were defined in `properties` but failed validation (e.g. format or type errors).