### PR TITLE
fix: keep $ref sibling keywords during getNode traversal (draft 2019-09+)

### DIFF
--- a/src/getNode.test.ts
+++ b/src/getNode.test.ts
@@ -533,4 +533,70 @@ describe("compileSchema : getNode", () => {
             });
         });
     });
+
+    describe("$ref sibling keywords", () => {
+        // @draft >= 2019-09: $ref is an applicator that combines with sibling
+        // keywords. getNode must keep those siblings (e.g. an `oneOf` of
+        // allowed values next to a $ref) instead of replacing them with the
+        // resolved target.
+        it("should keep an object property's oneOf sibling alongside a $ref", () => {
+            const root = compileSchema({
+                $schema: "https://json-schema.org/draft/2020-12/schema",
+                type: "object",
+                properties: {
+                    key: { $ref: "#/$defs/key", oneOf: [{ const: "a" }, { const: "b" }] }
+                },
+                $defs: { key: { type: "string" } }
+            });
+
+            const { error } = root.getNode("/key", { key: "" });
+            // data does not match the oneOf yet -> one-of-error carrying the schema
+            assert.equal(error?.code, "one-of-error");
+            assert.deepEqual(error?.data?.schema?.oneOf, [{ const: "a" }, { const: "b" }]);
+        });
+
+        it("should keep an array item's oneOf sibling alongside a $ref", () => {
+            const root = compileSchema({
+                $schema: "https://json-schema.org/draft/2020-12/schema",
+                type: "array",
+                items: { $ref: "#/$defs/key", oneOf: [{ const: "a" }, { const: "b" }] },
+                $defs: { key: { type: "string" } }
+            });
+
+            const { error } = root.getNode("/0", [""]);
+            assert.equal(error?.code, "one-of-error");
+            assert.deepEqual(error?.data?.schema?.oneOf, [{ const: "a" }, { const: "b" }]);
+        });
+
+        it("should reduce to the matching $ref-sibling branch for matching data", () => {
+            const root = compileSchema({
+                $schema: "https://json-schema.org/draft/2020-12/schema",
+                type: "array",
+                items: { $ref: "#/$defs/key", oneOf: [{ const: "a" }, { const: "b" }] },
+                $defs: { key: { type: "string", pattern: "^[a-z]$" } }
+            });
+
+            const { node, error } = root.getNode("/0", ["a"]);
+            assert.equal(error, undefined);
+            assert.equal(node?.schema?.const, "a");
+            assert.equal(node?.schema?.type, "string");
+        });
+
+        it("should ignore $ref siblings in draft-07", () => {
+            const root = compileSchema({
+                $schema: "http://json-schema.org/draft-07/schema",
+                type: "object",
+                properties: {
+                    key: { $ref: "#/definitions/key", oneOf: [{ const: "a" }, { const: "b" }] }
+                },
+                definitions: { key: { type: "string" } }
+            });
+
+            const { node, error } = root.getNode("/key", { key: "" });
+            // draft-07 ignores siblings of $ref: resolves to the bare target
+            assert.equal(error, undefined);
+            assert.equal(node?.schema?.oneOf, undefined);
+            assert.equal(node?.schema?.type, "string");
+        });
+    });
 });

--- a/src/getNodeChild.ts
+++ b/src/getNodeChild.ts
@@ -1,6 +1,16 @@
 import { GetNodeOptions, isSchemaNode, SchemaNode } from "./SchemaNode";
 import { isJsonError, NodeOrError, OptionalNodeOrError } from "./types";
 import { getValue } from "./utils/getValue";
+import { mergeNode } from "./mergeNode";
+
+/**
+ * `$ref` is an applicator in draft 2019-09 and later: it combines with any
+ * sibling keywords rather than replacing them. Those drafts register a `$ref`
+ * reducer, whereas draft-07 and earlier do not (their siblings are ignored).
+ */
+function hasRefReducer(node: SchemaNode): boolean {
+    return node.reducers.some((reducer) => (reducer.toJSON?.() ?? reducer.name) === "$ref");
+}
 
 export function getNodeChild(key: string | number, data: unknown, options: { withSchemaWarning: true } & GetNodeOptions): NodeOrError; // prettier-ignore
 export function getNodeChild(key: string | number, data: unknown, options: { createSchema: true } & GetNodeOptions): NodeOrError; // prettier-ignore
@@ -46,7 +56,19 @@ export function getNodeChild(
         }
         // a matching resolver found a child node, return
         if (isSchemaNode(schemaNode)) {
-            return { node: schemaNode.resolveRef({ pointer, path }), error: undefined };
+            const resolved = schemaNode.resolveRef({ pointer, path });
+            if (isJsonError(resolved)) {
+                return { node: undefined, error: resolved };
+            }
+            // @draft >= 2019-09: merge the child's sibling keywords onto the
+            // resolved target so assertions next to a $ref (e.g. an `oneOf`
+            // of allowed values) survive resolution. `$ref` is dropped from
+            // the merged schema as it has been resolved. Older drafts have no
+            // $ref reducer and retain the historical "siblings ignored" rule.
+            if (resolved !== schemaNode && hasRefReducer(schemaNode)) {
+                return { node: mergeNode(schemaNode, resolved, "$ref") ?? resolved, error: undefined };
+            }
+            return { node: resolved, error: undefined };
         }
     }
 


### PR DESCRIPTION
## Summary

In draft 2019-09 and later, `$ref` is an applicator that combines with its sibling keywords — `{ "$ref": …, "oneOf": [...] }` means "match the target **and** the `oneOf`". `validate()` honours this correctly (each sibling runs as an independent validator), but the **`getNode` traversal path does not**.

`getNodeChild` resolves a child `$ref` to the bare target via `resolveRef()`, discarding siblings:

```ts
// src/getNodeChild.ts
return { node: schemaNode.resolveRef({ pointer, path }), error: undefined };
```

(`resolveRef` → `compileNext` only carries over `settings.PROPERTIES_TO_MERGE` — title/description/etc. — never applicator keywords.)

So traversal silently drops the sibling constraint:

```ts
const root = compileSchema({
  $schema: "https://json-schema.org/draft/2020-12/schema",
  type: "array",
  items: { $ref: "#/$defs/key", oneOf: [{ const: "a" }, { const: "b" }] },
  $defs: { key: { type: "string" } }
});

root.getNode("/0", [""]);
// before: { node: { type: "string" } }   ← oneOf gone, no error
```

A **plain** `oneOf` (no `$ref`) already returns the expected `one-of-error` whose `error.data.schema` carries the full schema, so consumers that use `getNode` to enumerate allowed values (autocomplete, data generation) work in that case but not when a `$ref` is involved.

This appears to be a recent regression: the `resolveRef()` call was introduced in `fix: missing resolveRef in getNodeChild`, which resolved child refs (good) but to the bare target (dropping siblings). The official JSON Schema Test Suite only exercises `validate()`, so no spec test covers this traversal behaviour.

## Fix

In `getNodeChild`, merge the child's sibling keywords onto the resolved target (dropping the now-resolved `$ref`), **gated** on whether the draft registers a `$ref` reducer:

- draft 2019-09 / 2020-12 register a `$ref` reducer → siblings are merged (applicator semantics).
- draft-07 and earlier have no `$ref` reducer → unchanged, historical "siblings ignored" behaviour preserved.

`$ref` + `oneOf` now behaves identically to a plain `oneOf` at every location:

```ts
root.getNode("/0", [""]);
// after: one-of-error, error.data.schema.oneOf === [{const:"a"},{const:"b"}]
root.getNode("/0", ["a"]);
// after: reduces to the matching branch { type:"string", const:"a" }
```

## Tests

- Full multi-draft spec suite unchanged and green (draft 04/06/07/2019-09/2020-12).
- Added a `$ref sibling keywords` group to `src/getNode.test.ts` covering object-property, array-item, matching-data reduction, and the draft-07 "ignored" case.

## Notes

- Source + tests only; `dist/` is not included (regenerate on publish).
- Happy to adjust the approach — e.g. handling this inside `resolveRef`/`compileNext` instead of `getNodeChild` — but the `getNodeChild` gate keeps `resolveRef` returning target-only for `validate()`, which is what the independent-validator model expects. Open to your preference.