### PR TITLE
fix(ipv4): reject leading-zero octets, not addresses starting with 0 (#113)

### DIFF
--- a/src/formats/additionalFormats.ts
+++ b/src/formats/additionalFormats.ts
@@ -48,8 +48,8 @@ export const formats: Record<string, (options: JsonSchemaValidatorParams) => Val
         if (typeof data !== "string" || data === "") {
             return undefined;
         }
-        if (data && data[0] === "0") {
-            // leading zeroes should be rejected, as they are treated as octals
+        if (data && data.split(".").some((octet) => octet.length > 1 && octet[0] === "0")) {
+            // leading zeroes in an octet should be rejected, as they are treated as octals
             return node.createError("format-ipv4-leading-zero-error", { value: data, pointer, schema });
         }
         if (data.length <= 15 && isValidIPV4.test(data)) {

--- a/src/tests/issues/issue113.ipv4-leading-zero.test.ts
+++ b/src/tests/issues/issue113.ipv4-leading-zero.test.ts
@@ -1,0 +1,25 @@
+import { strict as assert } from "assert";
+import { compileSchema } from "../../compileSchema";
+
+// issue#113 — ipv4 format validator rejected valid addresses whose first octet
+// is "0" (e.g. 0.0.0.0). The guard meant to reject leading-zero *octets*
+// (octal-looking, e.g. 01.2.3.4), not any address starting with "0".
+describe("issue#113 - ipv4 format rejects valid 0.0.0.0 (over-broad leading-zero guard)", () => {
+    it("accepts 0.0.0.0 as a valid ipv4 address", () => {
+        const node = compileSchema({ $schema: "draft-07", format: "ipv4" });
+        const { errors } = node.validate("0.0.0.0");
+        assert.equal(errors?.length ?? 0, 0, "0.0.0.0 should be valid");
+    });
+
+    it("accepts 127.0.0.1 as a valid ipv4 address", () => {
+        const node = compileSchema({ $schema: "draft-07", format: "ipv4" });
+        const { errors } = node.validate("127.0.0.1");
+        assert.equal(errors?.length ?? 0, 0, "127.0.0.1 should be valid");
+    });
+
+    it("rejects 01.2.3.4 (leading zero in an octet, octal-like)", () => {
+        const node = compileSchema({ $schema: "draft-07", format: "ipv4" });
+        const { errors } = node.validate("01.2.3.4");
+        assert.notEqual(errors?.length ?? 0, 0, "01.2.3.4 should be rejected");
+    });
+});


### PR DESCRIPTION
## Problem
Fixes #113. The `ipv4` format validator rejected valid addresses whose first octet is `0`, like `0.0.0.0`, returning a leading-zero error. Confirmed on main `1cc2a30`.

## Root cause
The guard in `src/formats/additionalFormats.ts` (ipv4) checked whether the whole address starts with `"0"` (`if (data && data[0] === "0")`), but the comment intent is to reject leading-zero OCTETS (octal-looking, e.g. `01.2.3.4`), not any address starting with `0`. So `0.0.0.0` was wrongly rejected.

## Fix
Replace the whole-address check with a per-octet check: `data.split(".").some((octet) => octet.length > 1 && octet[0] === "0")`. Single-`0` octets (`0.0.0.0`) now pass; octal-like octets (`01.2.3.4`) still reject. The `isValidIPV4` regex is untouched. Two lines changed. `ipv6` left unchanged (its leading-zero semantics differ, out of scope for #113).

## How to test
`npm test -- --grep 113`
    accepts 0.0.0.0 as a valid ipv4 address
    accepts 127.0.0.1 as a valid ipv4 address
    rejects 01.2.3.4 (leading zero in an octet, octal-like)
3 passing. Full suite 8528 passing, 0 failing. The new test fails on main (bites) and passes with this change.

## Backward compatibility
No breaking changes. Addresses wrongly rejected (`0.0.0.0`) now validate; octal-like addresses (`01.2.3.4`) still reject.

---
Assisted-by: Claude (code generation, reviewed and tested locally)