### PR TITLE
fix: ignore failed anyOf/oneOf branches when computing evaluated items/properties (#117)

### DIFF
--- a/src/isItemEvaluated.ts
+++ b/src/isItemEvaluated.ts
@@ -43,7 +43,11 @@ export function isItemEvaluated({ node, data, key, pointer, path }: Options) {
     }
     if (node.anyOf) {
         for (const anyOf of node.anyOf) {
-            if (isItemEvaluated({ node: anyOf, data, key, pointer, path })) {
+            // only a branch that validates the data contributes evaluated-item state
+            if (
+                validateNode(anyOf, data, pointer, path).length === 0 &&
+                isItemEvaluated({ node: anyOf, data, key, pointer, path })
+            ) {
                 return true;
             }
         }
@@ -51,7 +55,11 @@ export function isItemEvaluated({ node, data, key, pointer, path }: Options) {
 
     if (node.oneOf) {
         for (const oneOf of node.oneOf) {
-            if (isItemEvaluated({ node: oneOf, data, key, pointer, path })) {
+            // only a branch that validates the data contributes evaluated-item state
+            if (
+                validateNode(oneOf, data, pointer, path).length === 0 &&
+                isItemEvaluated({ node: oneOf, data, key, pointer, path })
+            ) {
                 return true;
             }
         }

--- a/src/isPropertyEvaluated.ts
+++ b/src/isPropertyEvaluated.ts
@@ -51,7 +51,11 @@ export function isPropertyEvaluated({ node, data, key, pointer, path }: Options)
 
     if (node.anyOf) {
         for (const anyOf of node.anyOf) {
-            if (isPropertyEvaluated({ node: anyOf, data, key, pointer, path })) {
+            // only a branch that validates the data contributes evaluated-property state
+            if (
+                validateNode(anyOf, data, pointer, path).length === 0 &&
+                isPropertyEvaluated({ node: anyOf, data, key, pointer, path })
+            ) {
                 return true;
             }
         }
@@ -59,7 +63,11 @@ export function isPropertyEvaluated({ node, data, key, pointer, path }: Options)
 
     if (node.oneOf) {
         for (const oneOf of node.oneOf) {
-            if (isPropertyEvaluated({ node: oneOf, data, key, pointer, path })) {
+            // only a branch that validates the data contributes evaluated-property state
+            if (
+                validateNode(oneOf, data, pointer, path).length === 0 &&
+                isPropertyEvaluated({ node: oneOf, data, key, pointer, path })
+            ) {
                 return true;
             }
         }

--- a/src/keywords/unevaluatedItems.test.ts
+++ b/src/keywords/unevaluatedItems.test.ts
@@ -1,0 +1,59 @@
+import { compileSchema } from "../compileSchema";
+import { draft2020 } from "../draft2020";
+import { strict as assert } from "assert";
+
+describe("keyword : unevaluatedItems : validation", () => {
+    it("should not treat a failed anyOf branch's items:true as evaluating an item", () => {
+        const node = compileSchema(
+            {
+                anyOf: [
+                    // annotating but failing branch: items:true would mark index 0 as
+                    // evaluated, but maxItems:0 makes this branch invalid
+                    { items: true, maxItems: 0 },
+                    // succeeding but non-annotating branch
+                    { type: "array" }
+                ],
+                unevaluatedItems: false
+            },
+            { drafts: [draft2020] }
+        );
+
+        const { errors } = node.validate([1]);
+
+        const unevaluatedErrors = errors.filter((e) => e.code === "unevaluated-items-error");
+        assert.equal(unevaluatedErrors.length, 1, "failed anyOf branch must not suppress unevaluatedItems");
+    });
+
+    it("should not treat a failed oneOf branch's items:true as evaluating an item", () => {
+        const node = compileSchema(
+            {
+                oneOf: [
+                    { items: true, maxItems: 0 },
+                    { type: "array" }
+                ],
+                unevaluatedItems: false
+            },
+            { drafts: [draft2020] }
+        );
+
+        const { errors } = node.validate([1]);
+
+        const unevaluatedErrors = errors.filter((e) => e.code === "unevaluated-items-error");
+        assert.equal(unevaluatedErrors.length, 1, "failed oneOf branch must not suppress unevaluatedItems");
+    });
+
+    it("should still evaluate an item through a successful anyOf branch", () => {
+        const node = compileSchema(
+            {
+                anyOf: [{ items: true }],
+                unevaluatedItems: false
+            },
+            { drafts: [draft2020] }
+        );
+
+        const { errors } = node.validate([1]);
+
+        const unevaluatedErrors = errors.filter((e) => e.code === "unevaluated-items-error");
+        assert.equal(unevaluatedErrors.length, 0, "successful anyOf branch must still evaluate the item");
+    });
+});

--- a/src/keywords/unevaluatedProperties.test.ts
+++ b/src/keywords/unevaluatedProperties.test.ts
@@ -70,4 +70,58 @@ describe("keyword : unevaluatedProperties : validation", () => {
         const unevaluatedErrors = errors.filter((e) => e.code === "unevaluated-property-error");
         assert.equal(unevaluatedErrors.length, 1, "should flag unknown as unevaluated");
     });
+
+    it("should not treat a failed anyOf branch's additionalProperties as evaluating a property", () => {
+        const node = compileSchema(
+            {
+                anyOf: [
+                    // annotating but failing branch: additionalProperties:true would mark `x`
+                    // as evaluated, but maxProperties:0 makes this branch invalid
+                    { additionalProperties: true, maxProperties: 0 },
+                    // succeeding but non-annotating branch
+                    { type: "object" }
+                ],
+                unevaluatedProperties: false
+            },
+            { drafts: [draft2020] }
+        );
+
+        const { errors } = node.validate({ x: 1 });
+
+        const unevaluatedErrors = errors.filter((e) => e.code === "unevaluated-property-error");
+        assert.equal(unevaluatedErrors.length, 1, "failed anyOf branch must not suppress unevaluatedProperties");
+    });
+
+    it("should not treat a failed oneOf branch's additionalProperties as evaluating a property", () => {
+        const node = compileSchema(
+            {
+                oneOf: [
+                    { additionalProperties: true, maxProperties: 0 },
+                    { type: "object" }
+                ],
+                unevaluatedProperties: false
+            },
+            { drafts: [draft2020] }
+        );
+
+        const { errors } = node.validate({ x: 1 });
+
+        const unevaluatedErrors = errors.filter((e) => e.code === "unevaluated-property-error");
+        assert.equal(unevaluatedErrors.length, 1, "failed oneOf branch must not suppress unevaluatedProperties");
+    });
+
+    it("should still evaluate a property through a successful anyOf branch", () => {
+        const node = compileSchema(
+            {
+                anyOf: [{ additionalProperties: true }],
+                unevaluatedProperties: false
+            },
+            { drafts: [draft2020] }
+        );
+
+        const { errors } = node.validate({ x: 1 });
+
+        const unevaluatedErrors = errors.filter((e) => e.code === "unevaluated-property-error");
+        assert.equal(unevaluatedErrors.length, 0, "successful anyOf branch must still evaluate the property");
+    });
 });


### PR DESCRIPTION
## Summary

- `isItemEvaluated` and `isPropertyEvaluated` walk `anyOf`/`oneOf` branches to decide whether an item/property has already been evaluated (for `unevaluatedItems` / `unevaluatedProperties`).
- Unlike the sibling `if`/`contains` paths, the `anyOf`/`oneOf` loops recursed into **every** branch without first checking that the branch validates the data.
- As a result, a **failed** branch containing `items: true` or `additionalProperties: true` marked values as evaluated. When a separate non-annotating branch satisfied the combinator, `unevaluatedItems: false` / `unevaluatedProperties: false` was skipped and invalid instances returned `valid: true`.

Reproduction from #117 (all four returned `valid: true`, no errors, before this change):

```js
const schema = {
  $schema: "https://json-schema.org/draft/2020-12/schema",
  anyOf: [{ additionalProperties: true, maxProperties: 0 }, { type: "object" }],
  unevaluatedProperties: false
};
compileSchema(schema).validate({ x: 1 }); // was valid:true — should be invalid
```

## Fix

- Gate the `anyOf`/`oneOf` recursion on `validateNode(branch, data, pointer, path).length === 0` in both `src/isItemEvaluated.ts` and `src/isPropertyEvaluated.ts`, so only branches that actually validate the data contribute evaluated-item/property state. This mirrors the existing `if`-branch idiom already used in the same functions.
- `allOf` is intentionally left unchanged: a failing `allOf` branch already makes the whole instance invalid, so it cannot produce a false accept.

## Changes

- `src/isItemEvaluated.ts`: only recurse into a valid `anyOf`/`oneOf` branch.
- `src/isPropertyEvaluated.ts`: same, for properties.
- `src/keywords/unevaluatedItems.test.ts` (new): regression tests for the failed-branch case across `anyOf` and `oneOf`, plus a control asserting a successful branch still evaluates the item.
- `src/keywords/unevaluatedProperties.test.ts`: equivalent regression + control tests for properties.

## Verification

- The four new failed-branch tests fail on `main` and pass with the fix; the two "successful branch" controls pass both before and after (guarding against over-correction).
- Full unit suite compared before/after: no regressions — the only delta is these four tests moving from failing to passing (baseline 1072 failing → 1068 failing; the pre-existing failures are unrelated official JSON-Schema-Test-Suite `optional/format` cases). `eslint` clean on the touched files.

Fixes #117