### PR TITLE
fix: accumulate remote schema diagnostics instead of overwriting (#116)

### DIFF
--- a/src/SchemaNode.ts
+++ b/src/SchemaNode.ts
@@ -583,15 +583,20 @@ export const SchemaNodeMethods = {
         schemaValidation = sanitizeErrors(schemaValidation);
         const schemaErrors: JsonError[] = [];
         const schemaAnnotations: JsonAnnotation[] = [];
+        const remoteSchemaId = remoteNode.context.rootNode.$id ?? resolveUri(url);
         schemaValidation.forEach((error) => {
             if (isJsonError(error)) {
+                error.data.schemaId = remoteSchemaId;
                 schemaErrors.push(error);
             } else if (isJsonAnnotation(error)) {
+                error.data.schemaId = remoteSchemaId;
                 schemaAnnotations.push(error);
             }
         });
-        node.schemaErrors = schemaErrors;
-        node.schemaAnnotations = schemaAnnotations;
+        // accumulate diagnostics instead of overwriting so that registering
+        // multiple remotes retains all of their errors/annotations, see #116
+        node.schemaErrors = (node.schemaErrors ?? []).concat(schemaErrors);
+        node.schemaAnnotations = (node.schemaAnnotations ?? []).concat(schemaAnnotations);
 
         return node;
     },

--- a/src/tests/issues/issue116.remoteSchema.diagnostics.test.ts
+++ b/src/tests/issues/issue116.remoteSchema.diagnostics.test.ts
@@ -1,0 +1,33 @@
+import { strict as assert } from "assert";
+import { compileSchema } from "../../compileSchema";
+
+describe("issue#116 - addRemoteSchema overwrites earlier remote schema diagnostics", () => {
+    it("should keep diagnostics from all invalid remotes, not just the last one", () => {
+        const remotes = [
+            { $id: "https://a.example/schema", anyOf: [999] },
+            { $id: "https://b.example/schema", type: "invalid-type" }
+        ];
+
+        // @ts-expect-error remotes are intentionally invalid schemas for this test
+        const node = compileSchema({}, { remotes });
+
+        assert.equal(node.schemaErrors.length, 2, "errors from both remotes should be retained");
+
+        const pointers = node.schemaErrors.map((error) => error.data.pointer).sort();
+        assert.deepEqual(pointers, ["#/anyOf/0", "#/type"]);
+
+        const schemaIds = node.schemaErrors.map((error) => error.data.schemaId).sort();
+        assert.deepEqual(schemaIds, ["https://a.example/schema", "https://b.example/schema"]);
+    });
+
+    it("control: a single invalid remote still reports its error with schemaId", () => {
+        const remotes = [{ $id: "https://a.example/schema", anyOf: [999] }];
+
+        // @ts-expect-error remotes are intentionally invalid schemas for this test
+        const node = compileSchema({}, { remotes });
+
+        assert.equal(node.schemaErrors.length, 1);
+        assert.equal(node.schemaErrors[0].data.pointer, "#/anyOf/0");
+        assert.equal(node.schemaErrors[0].data.schemaId, "https://a.example/schema");
+    });
+});


### PR DESCRIPTION
Fixes #116

## Problem

`compileSchema`'s main compilation path accumulates `schemaErrors` / `schemaAnnotations`
correctly, but `addRemoteSchema` (called once per entry in `options.remotes`) **overwrote**
`node.schemaErrors` / `node.schemaAnnotations` on every call instead of appending to them.
It also never set `error.data.schemaId`, unlike the root compilation path.

As a result, registering multiple remotes only kept the *last* remote's diagnostics, and any
surviving error had `schemaId: undefined` — losing provenance and potentially letting invalid
remotes slip past `throwOnInvalidSchema`.

## Fix

In `SchemaNode.ts` → `addRemoteSchema`:
- Each error/annotation is now tagged with `error.data.schemaId`, resolved from the remote's
  own `$id` (falling back to the resolved `url`), matching how `compileSchema` tags root
  schema errors.
- `node.schemaErrors` / `node.schemaAnnotations` are now accumulated via `.concat(...)`
  instead of being reassigned, so registering multiple remotes retains all of their
  diagnostics.

## Tests

Added `src/tests/issues/issue116.remoteSchema.diagnostics.test.ts`:
- Regression test: two invalid remotes → both errors are retained, with correct pointers
  and `schemaId`s.
- Control test: a single invalid remote still reports correctly (same as before the fix).

## Verification

- Reproduced the exact repro script from the issue now returns both errors with correct
  `schemaId`s instead of just the last one.
- Full test suite passes with no new failures introduced (verified against a clean baseline
  with the fix stashed out).